### PR TITLE
Add texlive-luatex to list of optional Debian/Ubuntu dependencies

### DIFF
--- a/docs/installation/prerequisites.md
+++ b/docs/installation/prerequisites.md
@@ -16,7 +16,7 @@ We recommend to install the prerequisites using the packaging system of your dis
           git pandoc
 
       # optional, for pdf output
-      sudo apt install texlive texlive-xetex lmodern librsvg2-bin
+      sudo apt install texlive texlive-luatex texlive-xetex lmodern librsvg2-bin
 
    .. code-tab:: bash RHEL/CentOS
 


### PR DESCRIPTION
Since upgrading our server to Debian trixie, PDF output stopped working. This PR addresses this issue.
The package `texlive-luatex` is available in all recent Debian and Ubuntu releases, so it should not break anything.